### PR TITLE
Sayfa başlığındaki yazım hatası düzeltildi.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
       rel="stylesheet"
     />
 
-    <title>Türlçe Sözlük</title>
+    <title>Türkçe Sözlük</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
**Türlçe Sözlük** -> **Türkçe Sözlük** olarak değiştirildi